### PR TITLE
fix: (migration) drop foreign key before removing team_id

### DIFF
--- a/database/migrations/2025_03_06_084002_remove_team_id_and_percentage_add_predictions_in_championship_predictions_table.php
+++ b/database/migrations/2025_03_06_084002_remove_team_id_and_percentage_add_predictions_in_championship_predictions_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('championship_predictions', function (Blueprint $table) {
+            $table->dropForeign(['team_id']);
             $table->dropColumn('team_id');
             $table->dropColumn('probability_percentage');
             $table->jsonb('predictions');


### PR DESCRIPTION
During project setup, php artisan migrate failed because the team_id column was dropped without removing its foreign key. A drop foreign key method has been added to fix this.